### PR TITLE
Fix AffectBodyTemperatureEvent after change in AbstractValueModifiableEvent

### DIFF
--- a/src/main/java/org/terasology/climateConditions/AffectBodyTemperatureEvent.java
+++ b/src/main/java/org/terasology/climateConditions/AffectBodyTemperatureEvent.java
@@ -10,26 +10,7 @@ import org.terasology.entitySystem.event.AbstractValueModifiableEvent;
  * temperature.
  */
 public class AffectBodyTemperatureEvent extends AbstractValueModifiableEvent {
-    //The following additions are only needed because the AbstractValueModifiableEvent does not support negative base
-    // values at the moment.
-    private boolean isNegative = false;
-
     public AffectBodyTemperatureEvent(float baseValue) {
-        super((baseValue > 0) ? baseValue : (-1 * baseValue));
-        if (baseValue < 0) {
-            isNegative = true;
-        }
-    }
-
-    @Override
-    public float getResultValue() {
-        if (isNegative) {
-            return super.getResultValue() * -1;
-        }
-        return super.getResultValue();
-    }
-
-    public boolean isNegative() {
-        return isNegative;
+        super(baseValue);
     }
 }

--- a/src/main/java/org/terasology/climateConditions/BodyTemperatureSystem.java
+++ b/src/main/java/org/terasology/climateConditions/BodyTemperatureSystem.java
@@ -75,7 +75,7 @@ public class BodyTemperatureSystem extends BaseComponentSystem {
                 //Send event for other systems to modify change in body temperature.
                 AffectBodyTemperatureEvent affectBodyTemperatureEvent = new AffectBodyTemperatureEvent(deltaTemp);
                 entity.send(affectBodyTemperatureEvent);
-                deltaTemp = affectBodyTemperatureEvent.getResultValue();
+                deltaTemp = affectBodyTemperatureEvent.getResultValueWithoutCapping();
 
                 //Check for change in body temperature levels.
                 float oldValue = bodyTemperature.current;

--- a/src/main/java/org/terasology/climateConditions/alterationEffects/BodyTemperatureAlterationEffect.java
+++ b/src/main/java/org/terasology/climateConditions/alterationEffects/BodyTemperatureAlterationEffect.java
@@ -83,7 +83,7 @@ public class BodyTemperatureAlterationEffect implements AlterationEffect {
 
         // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
         // effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, magnitude, duration, this, id));
+        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, id));
         long modifiedDuration = 0;
         boolean modifiersFound = false;
 

--- a/src/main/java/org/terasology/climateConditions/alterationEffects/BodyTemperatureAlterationSystem.java
+++ b/src/main/java/org/terasology/climateConditions/alterationEffects/BodyTemperatureAlterationSystem.java
@@ -65,9 +65,10 @@ public class BodyTemperatureAlterationSystem extends BaseComponentSystem {
             if (affectBodyTemperatureComponent.condition == TemperatureAlterationCondition.ALWAYS) {
                 event.addPostMultiply(affectBodyTemperatureComponent.postMultiplier);
             } else {
-                if (affectBodyTemperatureComponent.condition == TemperatureAlterationCondition.ON_DECREASE && (event.getResultValueWithoutCapping() < 0)) {
+                float deltaTemp = event.getResultValueWithoutCapping();
+                if (affectBodyTemperatureComponent.condition == TemperatureAlterationCondition.ON_DECREASE && (deltaTemp < 0)) {
                     event.addPostMultiply(affectBodyTemperatureComponent.postMultiplier);
-                } else if (affectBodyTemperatureComponent.condition == TemperatureAlterationCondition.ON_INCREASE && (event.getResultValueWithoutCapping() > 0)) {
+                } else if (affectBodyTemperatureComponent.condition == TemperatureAlterationCondition.ON_INCREASE && (deltaTemp > 0)) {
                     event.addPostMultiply(affectBodyTemperatureComponent.postMultiplier);
                 }
             }

--- a/src/main/java/org/terasology/climateConditions/alterationEffects/BodyTemperatureAlterationSystem.java
+++ b/src/main/java/org/terasology/climateConditions/alterationEffects/BodyTemperatureAlterationSystem.java
@@ -44,7 +44,8 @@ public class BodyTemperatureAlterationSystem extends BaseComponentSystem {
     @Override
     public void initialise() {
         effectComponents.put(BodyTemperatureAlterationEffect.BODY_TEMPERATURE, AffectBodyTemperatureComponent.class);
-        alterationEffects.put(BodyTemperatureAlterationEffect.BODY_TEMPERATURE, new BodyTemperatureAlterationEffect(context));
+        alterationEffects.put(BodyTemperatureAlterationEffect.BODY_TEMPERATURE,
+                new BodyTemperatureAlterationEffect(context));
     }
 
     /**
@@ -64,9 +65,9 @@ public class BodyTemperatureAlterationSystem extends BaseComponentSystem {
             if (affectBodyTemperatureComponent.condition == TemperatureAlterationCondition.ALWAYS) {
                 event.addPostMultiply(affectBodyTemperatureComponent.postMultiplier);
             } else {
-                if (affectBodyTemperatureComponent.condition == TemperatureAlterationCondition.ON_DECREASE && event.isNegative()) {
+                if (affectBodyTemperatureComponent.condition == TemperatureAlterationCondition.ON_DECREASE && (event.getResultValueWithoutCapping() < 0)) {
                     event.addPostMultiply(affectBodyTemperatureComponent.postMultiplier);
-                } else if (affectBodyTemperatureComponent.condition == TemperatureAlterationCondition.ON_INCREASE && !event.isNegative()) {
+                } else if (affectBodyTemperatureComponent.condition == TemperatureAlterationCondition.ON_INCREASE && (event.getResultValueWithoutCapping() > 0)) {
                     event.addPostMultiply(affectBodyTemperatureComponent.postMultiplier);
                 }
             }


### PR DESCRIPTION
1. This is a follow up PR for and depends on: https://github.com/MovingBlocks/Terasology/pull/4123

2. Also sends out the correct values in onEffectModifyEvent in BodyTemperatureAlterationEffect
(Realized why the zero values were sent out after working in the Equipments module)