### PR TITLE
remove use of ImmutableBlockLocation in favor of Vector3i

### DIFF
--- a/src/main/java/org/terasology/climateConditions/HumidityGeneratorSystem.java
+++ b/src/main/java/org/terasology/climateConditions/HumidityGeneratorSystem.java
@@ -16,6 +16,8 @@
 package org.terasology.climateConditions;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
@@ -23,7 +25,7 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.logic.location.ImmutableBlockLocation;
+import org.terasology.math.JomlUtil;
 import org.terasology.registry.In;
 import org.terasology.world.block.BlockComponent;
 
@@ -34,43 +36,39 @@ public class HumidityGeneratorSystem extends BaseComponentSystem {
     @In
     private ClimateConditionsSystem environmentSystem;
 
-    private Map<ImmutableBlockLocation, HumidityGeneratorComponent> activeComponents = Maps.newHashMap();
+    private Map<Vector3i, HumidityGeneratorComponent> activeComponents = Maps.newHashMap();
 
     @Override
     public void preBegin() {
         environmentSystem.addHumidityModifier(1000,
-                new ConditionModifier() {
-                    @Override
-                    public float getCondition(float value, float x, float y, float z) {
-                        return getValue(value, x, y, z);
-                    }
-                });
+            (value, x, y, z) -> getValue(value, x, y, z));
     }
 
     @ReceiveEvent
     public void componentActivated(OnActivatedComponent event, HumidityGeneratorComponent generator, BlockComponent block) {
-        activeComponents.put(new ImmutableBlockLocation(block.getPosition()), generator);
+        activeComponents.put(JomlUtil.from(block.position), generator);
     }
 
     @ReceiveEvent
     public void componentUpdated(OnChangedComponent event, HumidityGeneratorComponent generator, BlockComponent block) {
-        activeComponents.put(new ImmutableBlockLocation(block.getPosition()), generator);
+        activeComponents.put(JomlUtil.from(block.position), generator);
     }
 
     @ReceiveEvent
     public void componentDeactivated(BeforeDeactivateComponent event, HumidityGeneratorComponent generator, BlockComponent block) {
-        activeComponents.remove(new ImmutableBlockLocation(block.getPosition()));
+        activeComponents.remove(JomlUtil.from(block.position));
     }
 
     private float getValue(float baseValue, float x, float y, float z) {
         float value = baseValue;
-        for (Map.Entry<ImmutableBlockLocation, HumidityGeneratorComponent> entry : activeComponents.entrySet()) {
-            ImmutableBlockLocation location = entry.getKey();
+        for (Map.Entry<Vector3i, HumidityGeneratorComponent> entry : activeComponents.entrySet()) {
+            Vector3i location = entry.getKey();
             HumidityGeneratorComponent generator = entry.getValue();
 
             if ((generator.humidity > value && generator.humidifier)
-                    || (generator.humidity < value && !generator.humidifier)) {
-                float distance = getDistance(x, y, z, location);
+                || (generator.humidity < value && !generator.humidifier)) {
+
+                float distance = Vector3f.distance(location.x, location.y, location.z, x, y, z);
                 if (distance <= generator.flatRange) {
                     value = generator.humidity;
                 } else if (distance < generator.maxRange) {
@@ -81,10 +79,5 @@ public class HumidityGeneratorSystem extends BaseComponentSystem {
         }
 
         return value;
-    }
-
-    private float getDistance(float x, float y, float z, ImmutableBlockLocation location) {
-        return (float) Math.sqrt((location.x - x) * (location.x - x)
-                + (location.y - y) * (location.y - y) + (location.z - z) * (location.z - z));
     }
 }


### PR DESCRIPTION
I replaced ImmustableBlockLocation in favor of just using Vecto3i just to simplify the implementation. we probably also want to have some test cases to verify these systems. My plan at the moment is to deprecate ImmustableBlockLocation in favor of just Vector3i since it doesn't add much and seems to complicate the implementation. 