### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/climateConditions/BodyTemperatureComponent.java
+++ b/src/main/java/org/terasology/climateConditions/BodyTemperatureComponent.java
@@ -31,7 +31,7 @@ public class BodyTemperatureComponent implements Component<BodyTemperatureCompon
 
     /** Stores the current body temperature level.*/
     @Replicate
-    BodyTemperatureLevel currentLevel = BodyTemperatureLevel.NORMAL;
+    public BodyTemperatureLevel currentLevel = BodyTemperatureLevel.NORMAL;
 
     @Override
     public void copyFrom(BodyTemperatureComponent other) {

--- a/src/main/java/org/terasology/climateConditions/alterationEffects/AffectBodyTemperatureComponent.java
+++ b/src/main/java/org/terasology/climateConditions/alterationEffects/AffectBodyTemperatureComponent.java
@@ -17,7 +17,7 @@ public class AffectBodyTemperatureComponent implements Component<AffectBodyTempe
      * 2. ON_INCREASE - when the change in temperature is positive.
      * 3. ALWAYS - modifies the change irrespective of whether it is positive or negative.
      */
-    TemperatureAlterationCondition condition;
+    public TemperatureAlterationCondition condition;
 
     @Override
     public void copyFrom(AffectBodyTemperatureComponent other) {


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191